### PR TITLE
fix(frontend): type-safe category guard, font-size floor, dynamic PDF filename

### DIFF
--- a/backend/internal/handler/pop.go
+++ b/backend/internal/handler/pop.go
@@ -2,8 +2,11 @@ package handler
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/akaitigo/pop-craft/backend/internal/model"
 	"github.com/akaitigo/pop-craft/backend/internal/pdf"
@@ -68,9 +71,28 @@ func GeneratePDF(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	filename := fmt.Sprintf("pop-%s-%d.pdf", safeFilenamePart(req.TemplateID), time.Now().Unix())
 	w.Header().Set("Content-Type", "application/pdf")
-	w.Header().Set("Content-Disposition", "attachment; filename=pop.pdf")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
 	if _, err := w.Write(data); err != nil {
 		log.Printf("failed to write pdf response: %v", err)
 	}
+}
+
+// safeFilenamePart strips any character that is not an ASCII letter, digit,
+// hyphen or underscore so user-supplied values (e.g. the template ID) cannot
+// inject characters into the Content-Disposition header or the file name.
+// It falls back to "pop" when nothing usable remains.
+func safeFilenamePart(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			b.WriteRune(r)
+		}
+	}
+	if b.Len() == 0 {
+		return "pop"
+	}
+	return b.String()
 }

--- a/backend/internal/handler/pop_internal_test.go
+++ b/backend/internal/handler/pop_internal_test.go
@@ -1,0 +1,27 @@
+package handler
+
+import "testing"
+
+func TestSafeFilenamePart(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"known template id", "super-recommend", "super-recommend"},
+		{"underscore kept", "draft_v2", "draft_v2"},
+		{"empty falls back", "", "pop"},
+		{"only unsafe falls back", "??!!/\\", "pop"},
+		{"strips crlf header injection", "a\r\nSet-Cookie: evil", "aSet-Cookieevil"},
+		{"strips quotes and spaces", `a b"c`, "abc"},
+		{"strips path traversal", "../../etc/passwd", "etcpasswd"},
+		{"keeps digits", "abc123", "abc123"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := safeFilenamePart(tt.input); got != tt.want {
+				t.Errorf("safeFilenamePart(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/handler/pop_test.go
+++ b/backend/internal/handler/pop_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 
 	"github.com/akaitigo/pop-craft/backend/internal/handler"
@@ -106,6 +107,35 @@ func TestGeneratePDF_Valid(t *testing.T) {
 	cd := resp.Header.Get("Content-Disposition")
 	if cd == "" {
 		t.Error("expected Content-Disposition header")
+	}
+}
+
+func TestGeneratePDF_DynamicFilename(t *testing.T) {
+	body := map[string]interface{}{
+		"product_name": "りんご",
+		"price":        198,
+		"template_id":  "super-recommend",
+		"paper_size":   "a4",
+	}
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/pop/pdf", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.GeneratePDF(w, req)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	cd := resp.Header.Get("Content-Disposition")
+	// Expect a dynamic name of the form pop-<templateID>-<unix>.pdf, no longer
+	// the static pop.pdf.
+	want := regexp.MustCompile(`^attachment; filename="pop-super-recommend-\d+\.pdf"$`)
+	if !want.MatchString(cd) {
+		t.Errorf("Content-Disposition = %q, want match %v", cd, want)
+	}
+	if cd == `attachment; filename=pop.pdf` {
+		t.Error("Content-Disposition is still the static pop.pdf")
 	}
 }
 

--- a/backend/internal/pdf/renderer.go
+++ b/backend/internal/pdf/renderer.go
@@ -43,7 +43,7 @@ func (r *Renderer) Render(w io.Writer) error {
 	pdf.AddPage()
 
 	fontSize := func(base float64) float64 {
-		return base * (width / 210.0)
+		return scaledFontSize(base, width)
 	}
 
 	// Background color from template
@@ -111,6 +111,22 @@ func (r *Renderer) Render(w io.Writer) error {
 	}
 
 	return pdf.Output(w)
+}
+
+// minFontSize is the smallest font size (in pt) the renderer will emit. Font
+// sizes are defined for A4 width and scaled down for smaller papers; without a
+// floor, card-sized output (55mm wide) shrinks 24pt text to ~6.3pt, which is
+// hard to read.
+const minFontSize = 7.0
+
+// scaledFontSize scales a base font size, defined for A4 width (210mm), to the
+// given paper width, clamping the result to minFontSize.
+func scaledFontSize(base, width float64) float64 {
+	size := base * (width / 210.0)
+	if size < minFontSize {
+		return minFontSize
+	}
+	return size
 }
 
 func hexToRGB(hex string) (int, int, int) {

--- a/backend/internal/pdf/renderer_internal_test.go
+++ b/backend/internal/pdf/renderer_internal_test.go
@@ -3,10 +3,39 @@ package pdf
 import (
 	"bytes"
 	"log"
+	"math"
 	"os"
 	"strings"
 	"testing"
 )
+
+func TestScaledFontSize(t *testing.T) {
+	tests := []struct {
+		name  string
+		base  float64
+		width float64
+		want  float64
+	}{
+		{"a4 no scaling", 24, 210, 24},
+		{"a4 large base", 36, 210, 36},
+		{"a5 scaled down", 24, 148, 24.0 * (148.0 / 210.0)},
+		{"card clamps to min", 24, 55, minFontSize},     // 6.28 -> 7
+		{"card small base clamps", 10, 55, minFontSize}, // 2.62 -> 7
+		{"card large base no clamp", 36, 55, 36.0 * (55.0 / 210.0)},
+		{"exactly min not clamped", minFontSize, 210, minFontSize},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := scaledFontSize(tt.base, tt.width)
+			if math.Abs(got-tt.want) > 1e-9 {
+				t.Errorf("scaledFontSize(%v, %v) = %v, want %v", tt.base, tt.width, got, tt.want)
+			}
+			if got < minFontSize {
+				t.Errorf("scaledFontSize(%v, %v) = %v is below minFontSize %v", tt.base, tt.width, got, minFontSize)
+			}
+		})
+	}
+}
 
 func TestHexToRGB_Valid(t *testing.T) {
 	tests := []struct {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -98,7 +98,9 @@ export default function Home() {
                     <p className="text-sm mt-1">{templateError}</p>
                     <button
                       type="button"
-                      onClick={() => setCategory(state.category!)}
+                      onClick={() => {
+                        if (state.category) setCategory(state.category);
+                      }}
                       className="mt-2 text-sm underline hover:no-underline"
                     >
                       再試行

--- a/frontend/src/components/PdfDownloadButton.test.tsx
+++ b/frontend/src/components/PdfDownloadButton.test.tsx
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { PdfDownloadButton } from "./PdfDownloadButton";
+import { generatePDF } from "@/lib/api";
 import type { POPRequest } from "@/types/pop";
 
 const mockRequest: POPRequest = {
@@ -18,6 +19,12 @@ const mockRequest: POPRequest = {
 vi.mock("@/lib/api", () => ({
   generatePDF: vi.fn(),
 }));
+
+const mockGeneratePDF = vi.mocked(generatePDF);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("PdfDownloadButton", () => {
   it("renders download button", () => {
@@ -37,5 +44,38 @@ describe("PdfDownloadButton", () => {
     fireEvent.click(button);
     // Button should show loading state
     expect(button).toBeDefined();
+  });
+
+  it("names the downloaded file pop-<templateID>-<unix>.pdf", async () => {
+    mockGeneratePDF.mockResolvedValue(
+      new Blob(["%PDF-1.4"], { type: "application/pdf" })
+    );
+
+    // jsdom does not implement the object URL APIs; stub and restore them.
+    const origCreate = URL.createObjectURL;
+    const origRevoke = URL.revokeObjectURL;
+    URL.createObjectURL = vi.fn(() => "blob:mock");
+    URL.revokeObjectURL = vi.fn();
+
+    let downloadName = "";
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        downloadName = this.download;
+      });
+
+    render(<PdfDownloadButton request={mockRequest} />);
+    fireEvent.click(screen.getByText("PDFダウンロード"));
+
+    await waitFor(() => expect(downloadName).not.toBe(""));
+
+    expect(downloadName).toMatch(/^pop-super-recommend-\d+\.pdf$/);
+    // Timestamp should be unix seconds (<= 11 digits), not milliseconds (13).
+    const ts = downloadName.match(/-(\d+)\.pdf$/)?.[1] ?? "";
+    expect(ts.length).toBeLessThanOrEqual(11);
+
+    clickSpy.mockRestore();
+    URL.createObjectURL = origCreate;
+    URL.revokeObjectURL = origRevoke;
   });
 });

--- a/frontend/src/components/PdfDownloadButton.tsx
+++ b/frontend/src/components/PdfDownloadButton.tsx
@@ -21,7 +21,9 @@ export function PdfDownloadButton({ request, disabled }: PdfDownloadButtonProps)
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = `pop-${request.template_id}-${Date.now()}.pdf`;
+      // Match the backend Content-Disposition format: pop-<templateID>-<unix>.pdf
+      const unix = Math.floor(Date.now() / 1000);
+      a.download = `pop-${request.template_id}-${unix}.pdf`;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);

--- a/frontend/src/lib/canvas/renderer.test.ts
+++ b/frontend/src/lib/canvas/renderer.test.ts
@@ -4,6 +4,8 @@ import {
   drawBackground,
   drawAccentBar,
   drawPrice,
+  scale,
+  MIN_FONT_SIZE,
 } from "./renderer";
 
 describe("getCanvasDimensions", () => {
@@ -30,6 +32,31 @@ describe("getCanvasDimensions", () => {
     const dims = getCanvasDimensions("a4", 210);
     expect(dims.width).toBe(210);
     expect(dims.height).toBe(297);
+  });
+});
+
+describe("scale", () => {
+  it("returns the base size at the reference width (420px)", () => {
+    expect(scale(28, 420)).toBe(28);
+    expect(scale(10, 420)).toBe(10);
+  });
+
+  it("scales down proportionally for narrower canvases", () => {
+    expect(scale(36, 210)).toBe(18);
+  });
+
+  it("clamps to MIN_FONT_SIZE for very small canvases", () => {
+    // 24 * (55/420) ≈ 3.1, below the floor
+    expect(scale(24, 55)).toBe(MIN_FONT_SIZE);
+    expect(scale(10, 55)).toBe(MIN_FONT_SIZE);
+  });
+
+  it("never returns below MIN_FONT_SIZE", () => {
+    for (const base of [8, 10, 12, 14, 24, 28, 36]) {
+      for (const width of [40, 55, 91, 210, 420]) {
+        expect(scale(base, width)).toBeGreaterThanOrEqual(MIN_FONT_SIZE);
+      }
+    }
   });
 });
 

--- a/frontend/src/lib/canvas/renderer.ts
+++ b/frontend/src/lib/canvas/renderer.ts
@@ -226,6 +226,13 @@ function contrastColor(hex: string): string {
   return luminance > 0.5 ? "#000000" : "#FFFFFF";
 }
 
-function scale(base: number, canvasWidth: number): number {
-  return Math.round(base * (canvasWidth / 420));
+// MIN_FONT_SIZE is the smallest font size (in px) the canvas renderer will
+// emit. Sizes are defined for a 420px-wide reference canvas and scaled down for
+// narrower ones; the floor keeps small papers (e.g. card size) legible, mirroring
+// the backend PDF renderer's minFontSize guard.
+export const MIN_FONT_SIZE = 7;
+
+export function scale(base: number, canvasWidth: number): number {
+  const size = Math.round(base * (canvasWidth / 420));
+  return Math.max(size, MIN_FONT_SIZE);
 }


### PR DESCRIPTION
## 概要
フロントエンド品質 3件をまとめて対応（一部バックエンドも含む）。

## 変更点
### #18 型安全性改善（非 null 断言除去）
- `frontend/src/app/page.tsx` の再試行ボタンで `state.category!` を `if (state.category)` 型ガードに置換。

### #15 Card 用紙のフォントサイズ最小値ガード
- Backend: `backend/internal/pdf/renderer.go` に `scaledFontSize()`（テスト容易化のためパッケージ関数へ抽出）+ `minFontSize = 7.0` を追加。card（幅55mm）で 24pt→約6.3pt に縮む問題を 7pt でクランプ。
- Frontend: `frontend/src/lib/canvas/renderer.ts` の `scale()` に `MIN_FONT_SIZE = 7` ガードを追加（export してテスト対象化）。
- 通常プレビュー（canvasWidth=420 / A4）では発火せず非破壊。

### #13 PDF ダウンロードファイル名を動的化
- Backend: `Content-Disposition` を `pop.pdf` 固定から `pop-<templateID>-<unix>.pdf` に変更。
  - **セキュリティ**: templateID はユーザー入力のためヘッダインジェクション対策として `safeFilenamePart()` で `[A-Za-z0-9_-]` 以外を除去（CRLF・引用符・パス区切り等を無害化）。
- Frontend: `PdfDownloadButton.tsx` の `a.download` を `Date.now()`（ms）から unix 秒に変更し、バックエンドの形式と一致させた。

## 検証
- Backend: `gofmt`（新規/変更ファイル）/ `go vet` / `go test -race ./...`（全パス）/ `go build` OK。
- Frontend: pnpm 9.15.9（CI と同一）で `typecheck` / `lint` / `test`（70 pass）/ `build` OK。

## テスト追加
- `pdf`: `TestScaledFontSize`（A4非スケール・A5縮小・card クランプ・境界値）
- `handler`: `TestGeneratePDF_DynamicFilename`（動的ファイル名の形式検証）, `TestSafeFilenamePart`（CRLF/引用符/パストラバーサル除去の white-box 検証）
- `renderer.test.ts`: `scale()` の最小値クランプ 4 ケース
- `PdfDownloadButton.test.tsx`: ダウンロードファイル名が `pop-<templateID>-<unix>.pdf`（unix 秒）であることを検証

## 備考（スコープ外・既存事象）
- `backend/internal/template/template.go` の `Template` 構造体タグに既存の gofmt 未整形（スキャフォールド由来）がありますが、本 PR のスコープ外のため未変更です。CI（go vet/test/build）・golangci-lint いずれもブロックしません。

fixes #18, fixes #15, fixes #13