### PR TITLE
ci: update actions/checkout v4 to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v4
         with:
           version: 9
@@ -38,7 +38,7 @@ jobs:
       run:
         working-directory: backend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-go@v5
         with:
           go-version: "1.23"


### PR DESCRIPTION
## 概要
actions/checkout を v4 から v7 に更新（Node.js 20 deprecation対応、期限2026-06-02の積み残し）。

## 破壊的変更の影響確認
- v5: Node 24化（GitHubホストランナーは対応済み）
- v6: 認証情報の別ファイル分離 → 本リポはcheckout認証に依存するstepなし
- v7: pull_request_target / workflow_run でのfork PRチェックアウト制限 → 本CIは push / pull_request トリガーのみ

## 検証
- actionlint パス
- YAML構文チェック パス