### PR TITLE
chore: Next.js生成型ファイルをGit管理対象外に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ frontend/node_modules/
 
 # Build
 frontend/.next/
+frontend/next-env.d.ts
 backend/bin/
 backend/server
 


### PR DESCRIPTION
## 変更内容

- Next.jsが生成する `frontend/next-env.d.ts` を `.gitignore` に追加

## 背景

ローカル開発後に生成ファイルが未追跡として残り、作業ツリーが不要に汚れる状態でした。

## 確認項目

- [x] `git check-ignore -v frontend/next-env.d.ts`
- [x] `git diff --check`

## 影響・リスク

生成ファイルのみが対象です。既存コードやビルド成果物には影響しません。