### PR TITLE
chore: next lintをESLint CLIへ移行する

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint src",
     "typecheck": "tsc --noEmit",
     "test": "vitest"
   },


### PR DESCRIPTION
## 概要

非推奨のnext lintをESLint CLIへ移行します。

Closes #28

## 変更内容

- lintスクリプトをnext lintからeslint srcへ変更
- 既存のFlat ConfigとNext.jsルールは維持
- 対象をsrcに限定し、生成物を誤って走査しないように設定

## 検証

- [x] pnpm lint（エラー0、既存警告1）
- [x] pnpm typecheck
- [x] pnpm test -- --run（70件成功）
- [x] pnpm build

## リスク

既存のフォント警告は移行前後で同一です。今回の目的外のため挙動変更は加えていません。