### PR TITLE
test: HTTPハンドラーテストのエラー処理を徹底する

### DIFF
--- a/backend/internal/handler/health_test.go
+++ b/backend/internal/handler/health_test.go
@@ -16,7 +16,7 @@ func TestHealth(t *testing.T) {
 	handler.Health(w, req)
 
 	resp := w.Result()
-	defer resp.Body.Close()
+	closeResponseBody(t, resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected status 200, got %d", resp.StatusCode)

--- a/backend/internal/handler/pop_test.go
+++ b/backend/internal/handler/pop_test.go
@@ -2,7 +2,6 @@ package handler_test
 
 import (
 	"bytes"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -22,7 +21,7 @@ func TestPreviewPOP_Valid(t *testing.T) {
 		"color_scheme": "red-gold",
 		"paper_size":   "a4",
 	}
-	b, _ := json.Marshal(body)
+	b := mustMarshalJSON(t, body)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/pop/preview", bytes.NewReader(b))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -30,7 +29,7 @@ func TestPreviewPOP_Valid(t *testing.T) {
 	handler.PreviewPOP(w, req)
 
 	resp := w.Result()
-	defer resp.Body.Close()
+	closeResponseBody(t, resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected 200, got %d", resp.StatusCode)
@@ -45,7 +44,7 @@ func TestPreviewPOP_InvalidBody(t *testing.T) {
 	handler.PreviewPOP(w, req)
 
 	resp := w.Result()
-	defer resp.Body.Close()
+	closeResponseBody(t, resp.Body)
 
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("expected 400, got %d", resp.StatusCode)
@@ -59,7 +58,7 @@ func TestPreviewPOP_MissingProductName(t *testing.T) {
 		"template_id":  "super-recommend",
 		"paper_size":   "a4",
 	}
-	b, _ := json.Marshal(body)
+	b := mustMarshalJSON(t, body)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/pop/preview", bytes.NewReader(b))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -67,7 +66,7 @@ func TestPreviewPOP_MissingProductName(t *testing.T) {
 	handler.PreviewPOP(w, req)
 
 	resp := w.Result()
-	defer resp.Body.Close()
+	closeResponseBody(t, resp.Body)
 
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("expected 400, got %d", resp.StatusCode)
@@ -85,7 +84,7 @@ func TestGeneratePDF_Valid(t *testing.T) {
 		"color_scheme": "red-gold",
 		"paper_size":   "a4",
 	}
-	b, _ := json.Marshal(body)
+	b := mustMarshalJSON(t, body)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/pop/pdf", bytes.NewReader(b))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -93,7 +92,7 @@ func TestGeneratePDF_Valid(t *testing.T) {
 	handler.GeneratePDF(w, req)
 
 	resp := w.Result()
-	defer resp.Body.Close()
+	closeResponseBody(t, resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected 200, got %d", resp.StatusCode)
@@ -117,7 +116,7 @@ func TestGeneratePDF_DynamicFilename(t *testing.T) {
 		"template_id":  "super-recommend",
 		"paper_size":   "a4",
 	}
-	b, _ := json.Marshal(body)
+	b := mustMarshalJSON(t, body)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/pop/pdf", bytes.NewReader(b))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -125,7 +124,7 @@ func TestGeneratePDF_DynamicFilename(t *testing.T) {
 	handler.GeneratePDF(w, req)
 
 	resp := w.Result()
-	defer resp.Body.Close()
+	closeResponseBody(t, resp.Body)
 
 	cd := resp.Header.Get("Content-Disposition")
 	// Expect a dynamic name of the form pop-<templateID>-<unix>.pdf, no longer
@@ -147,7 +146,7 @@ func TestGeneratePDF_InvalidBody(t *testing.T) {
 	handler.GeneratePDF(w, req)
 
 	resp := w.Result()
-	defer resp.Body.Close()
+	closeResponseBody(t, resp.Body)
 
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("expected 400, got %d", resp.StatusCode)

--- a/backend/internal/handler/template_test.go
+++ b/backend/internal/handler/template_test.go
@@ -20,7 +20,7 @@ func TestListTemplates(t *testing.T) {
 	handler.ListTemplates(w, req)
 
 	resp := w.Result()
-	defer resp.Body.Close()
+	closeResponseBody(t, resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", resp.StatusCode)
@@ -64,7 +64,7 @@ func TestGetTemplatesByCategory(t *testing.T) {
 			r.ServeHTTP(w, req)
 
 			resp := w.Result()
-			defer resp.Body.Close()
+			closeResponseBody(t, resp.Body)
 
 			if resp.StatusCode != tt.wantCode {
 				t.Errorf("expected status %d, got %d", tt.wantCode, resp.StatusCode)
@@ -97,7 +97,7 @@ func TestGetTemplatesByCategory_InvalidRejectedByAllowlist(t *testing.T) {
 			r.ServeHTTP(w, req)
 
 			resp := w.Result()
-			defer resp.Body.Close()
+			closeResponseBody(t, resp.Body)
 
 			if resp.StatusCode != http.StatusNotFound {
 				t.Fatalf("expected status 404, got %d", resp.StatusCode)

--- a/backend/internal/handler/test_helpers_test.go
+++ b/backend/internal/handler/test_helpers_test.go
@@ -1,0 +1,25 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"io"
+	"testing"
+)
+
+func closeResponseBody(t *testing.T, body io.Closer) {
+	t.Helper()
+	t.Cleanup(func() {
+		if err := body.Close(); err != nil {
+			t.Errorf("failed to close response body: %v", err)
+		}
+	})
+}
+
+func mustMarshalJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	b, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("failed to marshal request body: %v", err)
+	}
+	return b
+}


### PR DESCRIPTION
## 関連Issue

Closes #32

## 変更理由

HTTPハンドラーテストでレスポンスBodyのcloseエラーとJSON encodeエラーを処理しておらず、ローカル`make check`が`errcheck`違反で失敗していました。

## 変更内容

- `t.Cleanup`でレスポンスBodyを閉じ、エラーをテスト失敗として扱う共通helperを追加
- JSON encodeエラーを`Fatalf`で処理するhelperを追加
- handlerテストの未処理パターンをすべて置換

## 検証結果

- `make check`：成功
- frontend：70テスト成功、lint・typecheck・build成功
- backend：`golangci-lint` 0件、`go test -race ./...`成功、build成功
- gitleaks：秘密情報なし
- 既存の不正JSON・必須項目欠落・allowlist迂回テストを維持

## 影響範囲

テストコードのみ。本番のAPI・データ・互換性には影響しません。

## セキュリティ・運用

テスト内でもエラーを握りつぶさない基準へ統一します。共通helperは各テストの終了時に確実にcloseされます。