### PR TITLE
ops: Cloudflare Static Assetsの公開準備を整備する

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,6 +12,7 @@
 - TS: Zod でランタイムバリデーション, TailwindCSS
 - テストファイルは対象と同じディレクトリに配置
 - 本番画面へAPI依存を再導入する場合は、コスト・プライバシー・運用負荷をADRで再評価する
+- Cloudflareの外部Preview、Production deploy、secret登録はユーザー承認なしに実行しない
 
 ## テンプレート体系
 - 業態: supermarket, drugstore, bookstore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,11 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
           cache: pnpm
@@ -41,8 +41,8 @@ jobs:
       run:
         working-directory: backend
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.26.5"
           cache-dependency-path: backend/go.sum

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - run: pnpm typecheck
       - run: pnpm test -- --run
       - run: pnpm build
+      - run: node --test ../scripts/verify-static-assets.test.mjs
+      - run: node ../scripts/verify-static-assets.mjs
+      - run: pnpm exec wrangler deploy --dry-run --config ../wrangler.jsonc
 
   backend:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -31,6 +31,7 @@ jobs:
         env:
           TARGET: ${{ inputs.target }}
           CONFIRMATION: ${{ inputs.confirmation }}
+          SELECTED_REF: ${{ github.ref }}
         run: |
           case "${TARGET}:${CONFIRMATION}" in
             preview:PREVIEW|production:DEPLOY) ;;
@@ -39,21 +40,22 @@ jobs:
               exit 1
               ;;
           esac
+          if [ "${TARGET}" = "production" ] && [ "${SELECTED_REF}" != "refs/heads/main" ]; then
+            echo "productionはmain branchからのみ実行できます" >&2
+            exit 1
+          fi
 
   deploy:
     needs: validate-input
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: ${{ inputs.target }}
-    env:
-      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
           cache: pnpm
@@ -77,8 +79,14 @@ jobs:
       - name: Preview versionをupload
         if: inputs.target == 'preview'
         working-directory: frontend
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: pnpm exec wrangler versions upload --config ../wrangler.jsonc --preview-alias staging
       - name: Productionへdeploy
         if: inputs.target == 'production'
         working-directory: frontend
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: pnpm exec wrangler deploy --config ../wrangler.jsonc

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -1,0 +1,84 @@
+name: Cloudflareへ手動デプロイ
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "公開先（previewも公開URLを作成します）"
+        required: true
+        type: choice
+        options:
+          - preview
+          - production
+      confirmation:
+        description: "previewはPREVIEW、productionはDEPLOYと入力"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cloudflare-${{ inputs.target }}
+  cancel-in-progress: false
+
+jobs:
+  validate-input:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: 明示確認文字列を検証
+        env:
+          TARGET: ${{ inputs.target }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          case "${TARGET}:${CONFIRMATION}" in
+            preview:PREVIEW|production:DEPLOY) ;;
+            *)
+              echo "confirmationが一致しないため停止します" >&2
+              exit 1
+              ;;
+          esac
+
+  deploy:
+    needs: validate-input
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: ${{ inputs.target }}
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+      - name: 依存関係を固定lockfileから導入
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+      - name: 監査・lint・型・テスト・静的build
+        working-directory: frontend
+        run: |
+          pnpm audit --audit-level=low
+          pnpm lint
+          pnpm typecheck
+          pnpm test -- --run
+          pnpm build
+      - name: Static Assets成果物を検証
+        run: |
+          node --test scripts/verify-static-assets.test.mjs
+          node scripts/verify-static-assets.mjs
+          pnpm --dir frontend exec wrangler deploy --dry-run --config ../wrangler.jsonc
+      - name: Preview versionをupload
+        if: inputs.target == 'preview'
+        working-directory: frontend
+        run: pnpm exec wrangler versions upload --config ../wrangler.jsonc --preview-alias staging
+      - name: Productionへdeploy
+        if: inputs.target == 'production'
+        working-directory: frontend
+        run: pnpm exec wrangler deploy --config ../wrangler.jsonc

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ frontend/node_modules/
 frontend/.next/
 frontend/out/
 frontend/next-env.d.ts
+.wrangler/
 *.tsbuildinfo
 backend/bin/
 backend/server

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@
 make check          # lint + test + build 全チェック
 make dev            # frontendを開発モードで起動
 make dev-backend    # 比較検証用Go APIを起動
+make cloudflare-validate # Static Assets成果物とdry-runを検証
+make cloudflare-preview  # Wranglerのローカル配信
 make test           # 全テスト実行
 make lint           # 全lint実行
 make build          # 全ビルド
@@ -43,3 +45,4 @@ golangci-lint run    # lint
 - 本番用テンプレートの正本: `frontend/src/data/templates.ts`
 - 本番画面へGo API依存を再導入する場合は、コスト・プライバシー・運用負荷をADRで再評価する
 - 印刷: A4/A5/名刺を300 DPIで描画し、mm単位で出力する。変更時は`docs/PRINTING.md`の実PDF検証を再実行する
+- Cloudflare: 外部Preview、Production deploy、secret登録はユーザー承認後のみ。`docs/DEPLOYMENT.md`に従う

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check dev dev-backend test lint build cloudflare-validate cloudflare-preview clean
+.PHONY: check dev dev-backend test lint frontend-build build cloudflare-validate cloudflare-preview clean
 
 check: lint test build cloudflare-validate
 	@echo "All checks passed"
@@ -17,17 +17,18 @@ lint:
 	cd frontend && pnpm lint && pnpm typecheck
 	cd backend && golangci-lint run ./...
 
-build:
+frontend-build:
 	cd frontend && pnpm build
+
+build: frontend-build
 	cd backend && go build -o bin/server ./cmd/server
 
-cloudflare-validate:
+cloudflare-validate: frontend-build
 	node --test scripts/verify-static-assets.test.mjs
 	node scripts/verify-static-assets.mjs
 	cd frontend && pnpm exec wrangler deploy --dry-run --config ../wrangler.jsonc
 
-cloudflare-preview:
-	cd frontend && pnpm build
+cloudflare-preview: frontend-build
 	cd frontend && pnpm exec wrangler dev --config ../wrangler.jsonc
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: check dev dev-backend test lint build clean
+.PHONY: check dev dev-backend test lint build cloudflare-validate cloudflare-preview clean
 
-check: lint test build
+check: lint test build cloudflare-validate
 	@echo "All checks passed"
 
 dev:
@@ -20,6 +20,15 @@ lint:
 build:
 	cd frontend && pnpm build
 	cd backend && go build -o bin/server ./cmd/server
+
+cloudflare-validate:
+	node --test scripts/verify-static-assets.test.mjs
+	node scripts/verify-static-assets.mjs
+	cd frontend && pnpm exec wrangler deploy --dry-run --config ../wrangler.jsonc
+
+cloudflare-preview:
+	cd frontend && pnpm build
+	cd frontend && pnpm exec wrangler dev --config ../wrangler.jsonc
 
 clean:
 	rm -rf frontend/.next frontend/node_modules backend/bin

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ cd frontend && pnpm install && pnpm dev
 make check    # lint + test + build
 make dev      # 静的frontendを開発モードで起動
 make dev-backend # 比較検証用Go APIを起動
+make cloudflare-validate # Static Assets上限・header・dry-runを検証
+make cloudflare-preview  # Wranglerでローカル配信（外部公開なし）
 make test     # 全テスト実行
 make lint     # 全lint実行
 make build    # 全ビルド
@@ -100,6 +102,7 @@ pop-craft/
 
 - [PRD](docs/PRD.md) — プロダクト要件定義
 - [印刷ガイド](docs/PRINTING.md) — 対応用紙・設定・検証済みブラウザ
+- [デプロイrunbook](docs/DEPLOYMENT.md) — Cloudflare Preview / Production / rollback
 - [ADR-001](docs/adr/001-template-storage-strategy.md) — テンプレート保存戦略
 - [ADR-002](docs/adr/002-canvas-api-for-preview.md) — Canvas API採用理由
 - [ADR-003](docs/adr/ADR-003-static-first-deployment.md) — 固定費0円のブラウザ完結構成

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,123 @@
+# Cloudflare Workers Static Assets デプロイrunbook
+
+## 方針
+
+POP-CraftはWorker scriptを持たず、`frontend/out/`だけをWorkers Static Assetsへ配置します。2026-07-20時点のCloudflare公式仕様では、静的assetへの要求は無料・無制限で、保存の追加料金もありません。Freeプランの主な上限は1 version 20,000 files、1 file 25 MiBです。
+
+Wranglerは2026-07-20時点の最新版`4.112.0`をdevDependencyへ固定しています。更新時は公式の上限・設定schema・Preview・rollback仕様を再確認します。
+
+- Workers Paidへ切り替えない
+- R2、D1、KV、外部AI APIを追加しない
+- 最初の売上まで独自ドメインを購入せず、`workers.dev`を使う
+- Preview URLも公開URLであるため、ユーザー承認前にuploadしない
+- API token、account ID、商品情報をリポジトリやbundleへ入れない
+
+根拠:
+
+- [Static Assetsの料金と制限](https://developers.cloudflare.com/workers/static-assets/billing-and-limitations/)
+- [Workers / Static Assets上限](https://developers.cloudflare.com/workers/platform/limits/)
+- [Static Site Generation設定](https://developers.cloudflare.com/workers/static-assets/routing/static-site-generation/)
+- [Static Assetsのcustom headers](https://developers.cloudflare.com/workers/static-assets/headers/)
+
+## 構成
+
+- `wrangler.jsonc`: Worker名、`frontend/out`、404、HTML routingを固定
+- `frontend/public/_headers`: build時に`frontend/out/_headers`へコピー
+- `scripts/verify-static-assets.mjs`: Free上限、必須header、公開禁止文字列を検査
+- `.github/workflows/deploy-cloudflare.yml`: 明示入力付きの手動workflow
+
+`assets.run_worker_first`とWorker `main`は設定しません。将来追加する場合、静的要求がWorker課金・日次上限の対象になり得るため、別IssueとADRを必須とします。
+
+## Security header方針
+
+CSPの外部接続先はGoogle Fontsのstylesheetとfont fileだけです。`connect-src`は`self`だけなので、商品情報を外部APIへ送るfetch/XHRを遮断します。Next.jsのhydrationが生成するinline scriptと、用紙ごとに生成するinline `@page` styleのため、`script-src`と`style-src`には`unsafe-inline`が必要です。`unsafe-eval`は許可せず、`dangerouslySetInnerHTML`やユーザー入力由来のHTML/CSSを追加しません。
+
+将来Cloudflare Web Analytics等を追加する場合、CSP許可先を広げるだけの変更を行わず、収集データ・同意・プライバシー表記・送信先を別Issueでレビューします。
+
+## ローカル検証
+
+```bash
+pnpm --dir frontend install --frozen-lockfile
+make cloudflare-validate
+```
+
+`cloudflare-validate`は次を行い、Cloudflare accountへのupload・deployはしません。
+
+1. 検証scriptのnegative test
+2. build済み成果物の20,000 files / 25 MiB上限確認
+3. `index.html`、`404.html`、`_headers`の存在確認
+4. CSP等の必須header確認
+5. API URL・Cloudflare secret代入文字列のbundle scan
+6. `wrangler deploy --dry-run`
+
+Cloudflare相当のローカル配信は次で起動します。
+
+```bash
+make cloudflare-preview
+# Wranglerが表示するlocalhost URLだけを使用する
+```
+
+## 初回だけユーザーが行う設定
+
+このセクションは自動実行しません。
+
+1. Cloudflare FreeアカウントでWorkersを有効化し、Paidへ変更しない
+2. Account API TokensでWorkers Scriptsの編集権限を持つcustom tokenを作る
+3. tokenの対象resourceを使用する1 accountだけへ限定する
+4. GitHub repositoryの`preview`と`production` environmentへ次をsecret登録する
+   - `CLOUDFLARE_ACCOUNT_ID`
+   - `CLOUDFLARE_API_TOKEN`
+5. `production` environmentへ本人をrequired reviewerとして設定する
+6. Cloudflare dashboardでWorkers Logs、R2、D1、KV等が未使用であることを確認する
+
+API tokenは[Cloudflare公式GitHub Actions手順](https://developers.cloudflare.com/workers/ci-cd/external-cicd/github-actions/)に従い、リポジトリへ保存しません。
+
+## Preview手順
+
+Preview URLは公開されるため、ユーザーの公開承認後にのみ実行します。
+
+1. GitHub Actionsから「Cloudflareへ手動デプロイ」を選ぶ
+2. `target=preview`、`confirmation=PREVIEW`を指定する
+3. workflowが`wrangler versions upload --preview-alias staging`を実行する
+4. 出力されたURLでsmoke testを行う
+5. 問題があればProductionへ進まず、Issue化して修正する
+
+Preview URLの仕様は[Cloudflare公式Preview URLs](https://developers.cloudflare.com/workers/versions-and-deployments/preview-urls/)を参照してください。Preview URLはログ収集に対応しないため、ブラウザ確認とGitHub Actionsの結果を証跡にします。
+
+## Production手順
+
+1. Previewのsmoke test結果をPRまたはIssueへ記録する
+2. ユーザーが本番公開を最終承認する
+3. GitHub Actionsで`target=production`、`confirmation=DEPLOY`を指定する
+4. `production` environmentの承認画面で内容を再確認する
+5. deploy後10分以内にsmoke testを行う
+
+workflow_dispatch以外のpush、PR、scheduleではdeployしません。
+
+## Smoke test
+
+- `/`が200、存在しないpathが404
+- CSP、HSTS、nosniff、frame、Referrer、Permissions headersがある
+- スーパー→テンプレート→日本語入力→印刷プレビューが動く
+- A4・A5・名刺Canvasの寸法が`docs/PRINTING.md`と一致する
+- ConsoleにCSP violationとJavaScript errorがない
+- 商品情報を送るXHR / fetchが0件
+- `_next/static/`がimmutable cacheになる
+- モバイル幅390pxで横overflowがない
+
+## Rollback
+
+障害時は新規修正を待たず、直前の正常versionへ戻します。
+
+```bash
+cd frontend
+pnpm exec wrangler rollback --config ../wrangler.jsonc
+```
+
+version IDを指定する場合は`wrangler rollback <VERSION_ID>`を使います。rollbackは即時に対象versionを100% trafficへ適用します。実行後にSmoke testを再実行し、原因と影響をIssueへ記録します。詳細は[Cloudflare公式Rollback](https://developers.cloudflare.com/workers/versions-and-deployments/rollbacks/)を参照してください。
+
+token漏えい時はrollbackではなく、先にtoken revoke、GitHub secret削除、workflow停止、公開停止を行います。
+
+## 公開停止
+
+重大な秘密情報漏えい、意図しない外部通信、法務上の問題がある場合はCloudflare dashboardでroute / workers.devを無効化します。停止中はPreviewも作成せず、再公開にはユーザーの再承認を必要とします。

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -67,8 +67,10 @@ make cloudflare-preview
 4. GitHub repositoryの`preview`と`production` environmentへ次をsecret登録する
    - `CLOUDFLARE_ACCOUNT_ID`
    - `CLOUDFLARE_API_TOKEN`
-5. `production` environmentへ本人をrequired reviewerとして設定する
-6. Cloudflare dashboardでWorkers Logs、R2、D1、KV等が未使用であることを確認する
+5. `preview`と`production`の両environmentへ本人をrequired reviewerとして設定する
+   - 個人運用では自分で承認できるよう`Prevent self-review`を有効にしない
+6. `production` environmentのdeployment branchを`main`だけへ制限する
+7. Cloudflare dashboardでWorkers Logs、R2、D1、KV等が未使用であることを確認する
 
 API tokenは[Cloudflare公式GitHub Actions手順](https://developers.cloudflare.com/workers/ci-cd/external-cicd/github-actions/)に従い、リポジトリへ保存しません。
 
@@ -78,9 +80,10 @@ Preview URLは公開されるため、ユーザーの公開承認後にのみ実
 
 1. GitHub Actionsから「Cloudflareへ手動デプロイ」を選ぶ
 2. `target=preview`、`confirmation=PREVIEW`を指定する
-3. workflowが`wrangler versions upload --preview-alias staging`を実行する
-4. 出力されたURLでsmoke testを行う
-5. 問題があればProductionへ進まず、Issue化して修正する
+3. `preview` environmentの承認画面で内容を再確認する
+4. workflowが`wrangler versions upload --preview-alias staging`を実行する
+5. 出力されたURLでsmoke testを行う
+6. 問題があればProductionへ進まず、Issue化して修正する
 
 Preview URLの仕様は[Cloudflare公式Preview URLs](https://developers.cloudflare.com/workers/versions-and-deployments/preview-urls/)を参照してください。Preview URLはログ収集に対応しないため、ブラウザ確認とGitHub Actionsの結果を証跡にします。
 
@@ -88,11 +91,12 @@ Preview URLの仕様は[Cloudflare公式Preview URLs](https://developers.cloudfl
 
 1. Previewのsmoke test結果をPRまたはIssueへ記録する
 2. ユーザーが本番公開を最終承認する
-3. GitHub Actionsで`target=production`、`confirmation=DEPLOY`を指定する
+3. GitHub Actionsのbranchを`main`にし、`target=production`、`confirmation=DEPLOY`を指定する
 4. `production` environmentの承認画面で内容を再確認する
 5. deploy後10分以内にsmoke testを行う
 
 workflow_dispatch以外のpush、PR、scheduleではdeployしません。
+workflow内でもproductionは`refs/heads/main`以外から失敗させ、GitHub environment側のdeployment branch制限と二重化します。
 
 ## Smoke test
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -48,7 +48,7 @@
 | POP描画 | Canvas API |
 | テンプレート | 型付きTypeScript静的データ |
 | 印刷・PDF保存 | Browser Print API |
-| 本番インフラ | 静的ホスティング（Cloudflare Workers Static Assetsを第一候補） |
+| 本番インフラ | Cloudflare Workers Static Assets（外部公開はユーザー承認後） |
 | Backend | Go実装は比較検証用に保管。本番サイトからは未使用 |
 
 ## アーキテクチャ

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,11 +16,12 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@testing-library/react": "^16.1.0",
     "@testing-library/jest-dom": "^6.6.0",
+    "@testing-library/react": "^16.1.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.0",
     "eslint": "^9.0.0",
     "eslint-config-next": "^15.5.18",
     "jsdom": "^26.1.0",
@@ -28,7 +29,7 @@
     "tailwindcss": "^3.4.0",
     "typescript": "^5.7.0",
     "vitest": "^3.2.6",
-    "@vitejs/plugin-react": "^4.3.0"
+    "wrangler": "4.112.0"
   },
   "pnpm": {
     "overrides": {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       vitest:
         specifier: ^3.2.6
         version: 3.2.7(@types/node@22.19.17)(jiti@1.21.7)(jsdom@26.1.0)
+      wrangler:
+        specifier: 4.112.0
+        version: 4.112.0
 
 packages:
 
@@ -165,6 +168,53 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@cloudflare/kv-asset-handler@0.5.0':
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    engines: {node: '>=22.0.0'}
+
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: '>1.20260305.0 <2.0.0-0'
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260714.1':
+    resolution: {integrity: sha512-ZWXqAN8G7Cx9hMRQuk+59ziJhR3j1F4iO+Qs8aHdfKZ3Dq5Yi/57xvkJTgCGBnW1YU/L78r8f6HEy51bwbTpNw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260714.1':
+    resolution: {integrity: sha512-tueWxWC3wyCbMG6zRAxsMXX0YLgrRWbiAPYFQ2uJ7dUH8G+5E7UTWaQS9B1HdJ0bpKFW1NWxhs1o2noKVFSUYg==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260714.1':
+    resolution: {integrity: sha512-1VChTZRb0l0F7R4e1G5RtLKV4oFi6x+rQgxh2+yu887j3l/3TLgatuv1L8/5zhc9gKEhATTxOh0e52Rtd9dDWQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260714.1':
+    resolution: {integrity: sha512-rMm3G+NirG2UdgHIRDdF1asNC6FqgIzZzkRG+VDhhDGcVxAQwvrMT1E38BivEvHr3G04MB4AfhcOczX0+GtRkQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260714.1':
+    resolution: {integrity: sha512-cGqnU3Hg2YZS/k3SAqrMp1DjpdsyFde72tWltdl6ZT9+SFz/Zrk/8gyTU1TcxC4YApXeNVH5TyU5cOGPgUJ0pg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -566,6 +616,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -638,6 +691,15 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -772,6 +834,13 @@ packages:
 
   '@rushstack/eslint-patch@1.16.1':
     resolution: {integrity: sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==}
+
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
+  '@speed-highlight/core@1.2.17':
+    resolution: {integrity: sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -1152,6 +1221,9 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
   brace-expansion@1.1.16:
     resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
@@ -1230,6 +1302,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1341,6 +1417,9 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
   es-abstract@1.24.1:
     resolution: {integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==}
@@ -1867,6 +1946,10 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
 
@@ -1927,6 +2010,11 @@ packages:
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
+
+  miniflare@4.20260714.0:
+    resolution: {integrity: sha512-MYlTCLdWCPqvrYY2uLwOjXwmglXuiHE3TGGkbOW4BwjUPa1r07E0iuHwrNDIs/sxK21r+o90Jx58AV2KeNdJZw==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -2062,6 +2150,9 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -2375,6 +2466,10 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -2485,6 +2580,13 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -2625,6 +2727,21 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  workerd@1.20260714.1:
+    resolution: {integrity: sha512-oIbQzfdyl9UQUnG6XLegcSq0Mgt/7WKDbFOoqGgOWCS+/fhyGB460uKEgdAQQ9RHCO/ttcNCX/KiMIQzdoeu3Q==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.112.0:
+    resolution: {integrity: sha512-5H+XUD0TySCv1LuktFHDIEOkboH2nTfQs+35L+USt3MtntjDTMVIJprLgQcL2WBjulOyjxpd1vyTiSTJVW5MjQ==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^5.20260714.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   ws@8.21.1:
     resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
     engines: {node: '>=10.0.0'}
@@ -2650,6 +2767,12 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -2781,6 +2904,33 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@cloudflare/kv-asset-handler@0.5.0': {}
+
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260714.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260714.1
+
+  '@cloudflare/workerd-darwin-64@1.20260714.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260714.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260714.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260714.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260714.1':
+    optional: true
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
 
   '@csstools/color-helpers@5.1.0': {}
 
@@ -2953,8 +3103,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/colour@1.1.0':
-    optional: true
+  '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -3069,6 +3218,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.9.2
@@ -3119,6 +3273,18 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -3200,6 +3366,10 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.16.1': {}
+
+  '@sindresorhus/is@7.2.0': {}
+
+  '@speed-highlight/core@1.2.17': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -3621,6 +3791,8 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  blake3-wasm@2.1.5: {}
+
   brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
@@ -3708,6 +3880,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@1.1.1: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -3778,8 +3952,7 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   didyoumean@1.2.2: {}
 
@@ -3804,6 +3977,8 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   entities@6.0.1: {}
+
+  error-stack-parser-es@1.0.5: {}
 
   es-abstract@1.24.1:
     dependencies:
@@ -4521,6 +4696,8 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  kleur@4.1.5: {}
+
   language-subtag-registry@0.3.23: {}
 
   language-tags@1.0.9:
@@ -4570,6 +4747,18 @@ snapshots:
       picomatch: 2.3.2
 
   min-indent@1.0.1: {}
+
+  miniflare@4.20260714.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.28.0
+      workerd: 1.20260714.1
+      ws: 8.21.1
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   minimatch@10.2.5:
     dependencies:
@@ -4711,6 +4900,8 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-to-regexp@6.3.0: {}
 
   pathe@2.0.3: {}
 
@@ -4970,7 +5161,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -5099,6 +5289,8 @@ snapshots:
       pirates: 4.0.7
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
+
+  supports-color@10.2.2: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -5239,6 +5431,12 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.21.0: {}
+
+  undici@7.28.0: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
 
   unrs-resolver@1.11.1:
     dependencies:
@@ -5421,6 +5619,30 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  workerd@1.20260714.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260714.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260714.1
+      '@cloudflare/workerd-linux-64': 1.20260714.1
+      '@cloudflare/workerd-linux-arm64': 1.20260714.1
+      '@cloudflare/workerd-windows-64': 1.20260714.1
+
+  wrangler@4.112.0:
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260714.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.25.12
+      miniflare: 4.20260714.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260714.1
+    optionalDependencies:
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   ws@8.21.1: {}
 
   xml-name-validator@5.0.0: {}
@@ -5430,5 +5652,18 @@ snapshots:
   yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.17
+      cookie: 1.1.1
+      youch-core: 0.3.3
 
   zod@3.25.76: {}

--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -1,0 +1,12 @@
+/_next/static/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/*
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data:; connect-src 'self'; worker-src 'self'; manifest-src 'self'; upgrade-insecure-requests
+  Strict-Transport-Security: max-age=31536000; includeSubDomains
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: accelerometer=(), autoplay=(), camera=(), display-capture=(), encrypted-media=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), usb=()
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Resource-Policy: same-origin

--- a/scripts/verify-static-assets.mjs
+++ b/scripts/verify-static-assets.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+
+import { readFile, readdir, stat } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const FREE_FILE_LIMIT = 20_000;
+export const FILE_SIZE_LIMIT = 25 * 1024 * 1024;
+
+const REQUIRED_FILES = ["index.html", "404.html", "_headers"];
+const REQUIRED_HEADERS = [
+  "Content-Security-Policy:",
+  "Strict-Transport-Security:",
+  "X-Content-Type-Options: nosniff",
+  "X-Frame-Options: DENY",
+  "Referrer-Policy:",
+  "Permissions-Policy:",
+];
+const REQUIRED_CSP_DIRECTIVES = [
+  "default-src 'self'",
+  "object-src 'none'",
+  "frame-ancestors 'none'",
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "font-src 'self' https://fonts.gstatic.com data:",
+  "connect-src 'self'",
+];
+const FORBIDDEN_TEXT = [
+  "NEXT_PUBLIC_API_URL",
+  "localhost:8080",
+  "/api/v1/",
+  "CLOUDFLARE_API_TOKEN",
+  "CLOUDFLARE_ACCOUNT_ID",
+  "CF_API_TOKEN",
+];
+const TEXT_EXTENSIONS = new Set([
+  ".css",
+  ".html",
+  ".js",
+  ".json",
+  ".map",
+  ".svg",
+  ".txt",
+  ".webmanifest",
+  ".xml",
+]);
+
+async function collectFiles(directory, rootDirectory = directory) {
+  const files = [];
+  const entries = await readdir(directory, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isSymbolicLink()) {
+      throw new Error(
+        `静的成果物にシンボリックリンクは含められません: ${path.relative(rootDirectory, absolutePath)}`
+      );
+    }
+    if (entry.isDirectory()) {
+      files.push(...(await collectFiles(absolutePath, rootDirectory)));
+    } else if (entry.isFile()) {
+      const fileStat = await stat(absolutePath);
+      files.push({
+        absolutePath,
+        relativePath: path.relative(rootDirectory, absolutePath),
+        size: fileStat.size,
+      });
+    }
+  }
+
+  return files;
+}
+
+function isTextFile(relativePath) {
+  return (
+    path.basename(relativePath) === "_headers" ||
+    TEXT_EXTENSIONS.has(path.extname(relativePath))
+  );
+}
+
+export async function verifyStaticAssets(outputDirectory) {
+  const files = await collectFiles(outputDirectory);
+  const relativePaths = new Set(files.map((file) => file.relativePath));
+  const errors = [];
+
+  for (const requiredFile of REQUIRED_FILES) {
+    if (!relativePaths.has(requiredFile)) {
+      errors.push(`必須ファイルがありません: ${requiredFile}`);
+    }
+  }
+
+  if (files.length > FREE_FILE_LIMIT) {
+    errors.push(
+      `Free上限を超えています: ${files.length} files > ${FREE_FILE_LIMIT} files`
+    );
+  }
+
+  for (const file of files) {
+    if (file.size > FILE_SIZE_LIMIT) {
+      errors.push(
+        `Free上限を超えるファイルです: ${file.relativePath} (${file.size} bytes)`
+      );
+    }
+
+    if (!isTextFile(file.relativePath)) continue;
+    const content = await readFile(file.absolutePath, "utf8");
+    for (const forbiddenText of FORBIDDEN_TEXT) {
+      if (content.includes(forbiddenText)) {
+        errors.push(
+          `公開禁止文字列を検出しました: ${file.relativePath}: ${forbiddenText}`
+        );
+      }
+    }
+  }
+
+  if (relativePaths.has("_headers")) {
+    const headers = await readFile(path.join(outputDirectory, "_headers"), "utf8");
+    for (const requiredHeader of REQUIRED_HEADERS) {
+      if (!headers.includes(requiredHeader)) {
+        errors.push(`必須セキュリティヘッダーがありません: ${requiredHeader}`);
+      }
+    }
+    for (const directive of REQUIRED_CSP_DIRECTIVES) {
+      if (!headers.includes(directive)) {
+        errors.push(`必須CSP directiveがありません: ${directive}`);
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(errors.join("\n"));
+  }
+
+  const largestFile = files.reduce(
+    (largest, file) => (file.size > largest.size ? file : largest),
+    { relativePath: "-", size: 0 }
+  );
+
+  return {
+    fileCount: files.length,
+    largestFile: largestFile.relativePath,
+    largestFileSize: largestFile.size,
+  };
+}
+
+async function main() {
+  const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+  const repositoryRoot = path.resolve(scriptDirectory, "..");
+  const outputDirectory = path.resolve(
+    repositoryRoot,
+    process.argv[2] ?? "frontend/out"
+  );
+  const result = await verifyStaticAssets(outputDirectory);
+  console.log(
+    `Static Assets検証成功: ${result.fileCount}/${FREE_FILE_LIMIT} files, 最大 ${result.largestFileSize}/${FILE_SIZE_LIMIT} bytes (${result.largestFile})`
+  );
+}
+
+const isDirectExecution =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isDirectExecution) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/verify-static-assets.mjs
+++ b/scripts/verify-static-assets.mjs
@@ -8,14 +8,14 @@ export const FREE_FILE_LIMIT = 20_000;
 export const FILE_SIZE_LIMIT = 25 * 1024 * 1024;
 
 const REQUIRED_FILES = ["index.html", "404.html", "_headers"];
-const REQUIRED_HEADERS = [
-  "Content-Security-Policy:",
-  "Strict-Transport-Security:",
-  "X-Content-Type-Options: nosniff",
-  "X-Frame-Options: DENY",
-  "Referrer-Policy:",
-  "Permissions-Policy:",
-];
+const REQUIRED_GLOBAL_HEADERS = new Map([
+  ["content-security-policy", null],
+  ["strict-transport-security", null],
+  ["x-content-type-options", "nosniff"],
+  ["x-frame-options", "DENY"],
+  ["referrer-policy", "strict-origin-when-cross-origin"],
+  ["permissions-policy", null],
+]);
 const REQUIRED_CSP_DIRECTIVES = [
   "default-src 'self'",
   "object-src 'none'",
@@ -78,6 +78,35 @@ function isTextFile(relativePath) {
   );
 }
 
+function parseHeaderRules(content) {
+  const rules = new Map();
+  let currentHeaders;
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+
+    if (!/^\s/.test(rawLine)) {
+      currentHeaders = new Map();
+      rules.set(line, currentHeaders);
+      continue;
+    }
+
+    if (!currentHeaders) {
+      throw new Error(`routeより前にheaderがあります: ${line}`);
+    }
+    const separator = line.indexOf(":");
+    if (separator <= 0) {
+      throw new Error(`不正なheader行です: ${line}`);
+    }
+    const name = line.slice(0, separator).trim().toLowerCase();
+    const value = line.slice(separator + 1).trim();
+    currentHeaders.set(name, value);
+  }
+
+  return rules;
+}
+
 export async function verifyStaticAssets(outputDirectory) {
   const files = await collectFiles(outputDirectory);
   const relativePaths = new Set(files.map((file) => file.relativePath));
@@ -115,15 +144,39 @@ export async function verifyStaticAssets(outputDirectory) {
 
   if (relativePaths.has("_headers")) {
     const headers = await readFile(path.join(outputDirectory, "_headers"), "utf8");
-    for (const requiredHeader of REQUIRED_HEADERS) {
-      if (!headers.includes(requiredHeader)) {
-        errors.push(`必須セキュリティヘッダーがありません: ${requiredHeader}`);
+    let rules;
+    try {
+      rules = parseHeaderRules(headers);
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : String(error));
+    }
+
+    const globalHeaders = rules?.get("/*");
+    if (!globalHeaders) {
+      errors.push("global header rule `/*` がありません");
+    } else {
+      for (const [name, expectedValue] of REQUIRED_GLOBAL_HEADERS) {
+        const actualValue = globalHeaders.get(name);
+        if (actualValue === undefined) {
+          errors.push(`global ruleに必須headerがありません: ${name}`);
+        } else if (expectedValue !== null && actualValue !== expectedValue) {
+          errors.push(
+            `global ruleのheader値が不正です: ${name}: ${actualValue}`
+          );
+        }
+      }
+
+      const csp = globalHeaders.get("content-security-policy") ?? "";
+      for (const directive of REQUIRED_CSP_DIRECTIVES) {
+        if (!csp.includes(directive)) {
+          errors.push(`global ruleに必須CSP directiveがありません: ${directive}`);
+        }
       }
     }
-    for (const directive of REQUIRED_CSP_DIRECTIVES) {
-      if (!headers.includes(directive)) {
-        errors.push(`必須CSP directiveがありません: ${directive}`);
-      }
+
+    const staticCache = rules?.get("/_next/static/*")?.get("cache-control");
+    if (staticCache !== "public, max-age=31536000, immutable") {
+      errors.push("fingerprinted assetのimmutable cache ruleが不正です");
     }
   }
 

--- a/scripts/verify-static-assets.test.mjs
+++ b/scripts/verify-static-assets.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { verifyStaticAssets } from "./verify-static-assets.mjs";
+
+const VALID_HEADERS = `/*
+  Content-Security-Policy: default-src 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self'
+  Strict-Transport-Security: max-age=31536000
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=()
+`;
+
+async function createFixture() {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "pop-craft-assets-"));
+  await writeFile(path.join(directory, "index.html"), "<!doctype html>");
+  await writeFile(path.join(directory, "404.html"), "not found");
+  await writeFile(path.join(directory, "_headers"), VALID_HEADERS);
+  return directory;
+}
+
+test("有効な静的成果物を受理する", async (t) => {
+  const directory = await createFixture();
+  t.after(() => rm(directory, { recursive: true, force: true }));
+
+  const result = await verifyStaticAssets(directory);
+  assert.equal(result.fileCount, 3);
+});
+
+test("必須headerの欠落を拒否する", async (t) => {
+  const directory = await createFixture();
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  await writeFile(path.join(directory, "_headers"), "/*\n  X-Frame-Options: DENY\n");
+
+  await assert.rejects(
+    verifyStaticAssets(directory),
+    /必須セキュリティヘッダーがありません/
+  );
+});
+
+test("API参照を含むbundleを拒否する", async (t) => {
+  const directory = await createFixture();
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const chunkDirectory = path.join(directory, "_next", "static");
+  await mkdir(chunkDirectory, { recursive: true });
+  await writeFile(
+    path.join(chunkDirectory, "app.js"),
+    'fetch("http://localhost:8080/api/v1/templates")'
+  );
+
+  await assert.rejects(
+    verifyStaticAssets(directory),
+    /公開禁止文字列を検出しました/
+  );
+});

--- a/scripts/verify-static-assets.test.mjs
+++ b/scripts/verify-static-assets.test.mjs
@@ -12,6 +12,9 @@ const VALID_HEADERS = `/*
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=()
+
+/_next/static/*
+  Cache-Control: public, max-age=31536000, immutable
 `;
 
 async function createFixture() {
@@ -37,7 +40,21 @@ test("必須headerの欠落を拒否する", async (t) => {
 
   await assert.rejects(
     verifyStaticAssets(directory),
-    /必須セキュリティヘッダーがありません/
+    /global ruleに必須headerがありません/
+  );
+});
+
+test("別routeのheaderでglobal ruleの欠落を隠せない", async (t) => {
+  const directory = await createFixture();
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  await writeFile(
+    path.join(directory, "_headers"),
+    VALID_HEADERS.replace("/*", "/admin/*")
+  );
+
+  await assert.rejects(
+    verifyStaticAssets(directory),
+    /global header rule `\/\*` がありません/
   );
 });
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,12 @@
+{
+  "$schema": "./frontend/node_modules/wrangler/config-schema.json",
+  "name": "pop-craft",
+  "compatibility_date": "2026-07-20",
+  "workers_dev": true,
+  "preview_urls": true,
+  "assets": {
+    "directory": "./frontend/out",
+    "html_handling": "auto-trailing-slash",
+    "not_found_handling": "404-page"
+  }
+}


### PR DESCRIPTION
## 関連Issue

Closes #40

## 問題

静的exportは可能でしたが、Cloudflare向け設定、security headers、Free上限検査、承認付きdeploy、rollback runbookがなく、手作業では公開事故と復旧遅延のリスクがありました。

## 変更内容

- Wrangler 4.112.0をdevDependencyへ固定
- `wrangler.jsonc`で`frontend/out`、404、HTML routing、Preview URLを明示
- Worker scriptを持たないStatic Assets専用構成へ固定
- `_headers`へCSP、HSTS、nosniff、frame、Referrer、Permissions、COOP/CORPを追加
- fingerprinted Next.js assetsへ1年immutable cacheを設定
- file数・file size・必須header・CSP・API/secret文字列を検査するNode scriptとnegative testを追加
- 通常CIへ成果物検査と`wrangler deploy --dry-run`を追加
- `PREVIEW` / `DEPLOY`明示入力、environment承認、最小`contents: read`権限の手動workflowを追加
- 初回secret登録、Preview、Production、smoke test、rollback、公開停止を日本語runbookへ記載

## 0円方針

2026-07-20時点のCloudflare公式仕様では純粋なStatic Assets要求は無料・無制限、保存追加料金なしです。Free上限20,000 files/version・25 MiB/fileを自動検査します。Worker `main`、`run_worker_first`、R2、D1、KVは追加していません。

## 検証結果

- `make check`: 成功
- frontend: lintエラー0、typecheck、87 tests、static build成功
- backend: lint、race test、build成功
- Node native test: 4件成功（正常、header欠落、API参照拒否）
- Static Assets検査: 21/20,000 files、最大189,763/26,214,400 bytes
- `wrangler deploy --dry-run`: 成功、bindings 0
- `pnpm audit --audit-level=low`: 既知脆弱性0件
- actionlint: CI / deploy workflowとも成功
- gitleaks staged scan: 秘密情報なし

## Wranglerローカル実ブラウザ検証

- `/`: 200、未知path: 404
- 全security headersを確認
- `/_next/static/`: `immutable` cacheを確認
- CSP violation / JavaScript error: 0件
- 業態→テンプレート→印刷プレビュー: 成功
- A4印刷Canvas: 2480×3508
- XHR / fetch: 0件
- 横overflow: なし

## セキュリティ上の判断

Next.js hydrationのinline scriptと動的`@page` styleにより`unsafe-inline`は必要ですが、`unsafe-eval`は許可していません。外部許可先はGoogle Fontsだけで、`connect-src self`により商品情報の外部送信を遮断します。

## 実行していないこと

- Cloudflare login / API token作成・登録
- Preview version upload
- Production deploy
- workers.dev公開
- Paid変更、独自ドメイン購入、外部サービス追加

これらはユーザーの最終確認後にのみ実行します。

## 残存リスク

- Preview URL自体も公開URL
- `unsafe-inline`を完全には除去できない
- Google Fonts障害時は既存のfallback警告へ移行
- GitHub production environmentのrequired reviewerはユーザー設定が必要

## ロールバック

`wrangler rollback`で直前の正常versionへ即時復旧します。token漏えい時は先にtoken revoke、GitHub secret削除、workflow停止、公開停止を行います。
